### PR TITLE
meta: front-door repo scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI (lint-readme)
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  readme-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check files exist
+        run: |
+          test -f README.md
+          test -f ARCHITECTURE.md
+          test -f REPO-MAP.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,21 @@
+# Architecture (4 Buckets)
+
+Goblin is organised into four conceptual buckets. Buckets are **meta categories**; the real units are the repos they group.
+
+1) **User, Developer & Agentic Experiences**
+   Wallet (web/mobile), Developer Console, first bot (tranched staking), agentic UX.
+
+2) **On-Chain Core (Solana)**
+   Anchor programs: Bot Factory, Master, Individual Bot; token configs; treasuries.
+
+3) **Off-Chain Smarts (platform-agnostic)**
+   API, Indexer, Timekeeper; SDK + CLI; CI/CD and observability. Cloud-agnostic.
+
+4) **Governance & Economics**
+   Treasury policy, upgrade/pause rules, tokenomics, future DAO.
+
+**Now vs Future**
+- Now: wallet, dev console, programs, services (API/indexer/timekeeper), SDK/CLI, first bot.
+- Future: more bots (added as separate repos), Swap, Stake UX, DAO.
+
+Principle: **Open where it builds trust. Private where it protects money.**

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 gapview01
+Copyright (c) 2025 Goblin contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# goblin
-Goblin is a Solana agent wallet – more creature than app. It’s your entry to our modular ecosystem of bots, on‑chain programs, off‑chain services and governance. This repo maps the pieces and links you to the code.
+# Goblin — Solana Agent Wallet
+Not an app, a money creature.
+
+This is the **front door** to the Goblin ecosystem: a minimal map of what Goblin is, how it’s structured, and where to find the code.
+
+- Vision & layers: see **ARCHITECTURE.md**
+- Repos & links: see **REPO-MAP.md**
+
+We keep Goblin modular and open. Critical ops remain private.

--- a/REPO-MAP.md
+++ b/REPO-MAP.md
@@ -1,0 +1,22 @@
+# Repository Map
+
+Buckets are conceptual; repos are the unit of analysis. Links are added as repos go live.
+
+## 1) User, Developer & Agentic Experiences (public)
+- goblin-wallet — Web/Mobile wallet
+- goblin-developer-console — Dev portal & control panel
+- goblin-bot-staking — First bot (tranched liquid staking)
+
+## 2) On-Chain Core (public)
+- goblin-programs — Anchor programs (Factory, Master, Bot)
+- goblin-tokens — Token metadata/configs
+
+## 3) Off-Chain Smarts (public/private)
+- goblin-services — API, Indexer, Timekeeper (logic only)
+- goblin-sdk — Client SDK
+- goblin-cli — CLI tools
+- goblin-infra — *(private)* IaC, pipelines, secrets
+
+## 4) Governance & Economics
+- goblin-dao — *(public scaffold)* future DAO/contracts/UI
+- goblin-governance-private — *(private)* treasury policy, tokenomics, governance docs

--- a/docs/diagram-placeholder.md
+++ b/docs/diagram-placeholder.md
@@ -1,0 +1,2 @@
+# Diagram Placeholder
+A simple diagram of the 4 buckets and satellites will live here. Keep the front door minimal.


### PR DESCRIPTION
## Summary
- add minimal front door README, architecture overview, and repo map
- include MIT license, diagram placeholder, and README presence CI

## Testing
- `bash -lc 'test -f README.md && test -f ARCHITECTURE.md && test -f REPO-MAP.md && echo files-ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b278c012b88322aca8d81fb17ccb74