### PR TITLE
docs: add goblin-treasury repo to architecture & repo map

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,8 @@ Goblin is organised into four conceptual buckets. Buckets are **meta categories*
 
 4) **Governance & Economics**
    Treasury policy, upgrade/pause rules, tokenomics, future DAO.
+   - goblin-treasury (private) — operational repo for Goblin’s treasuries:
+     wallet lists, fee flows, multisig signer roles, reconciliation & incident runbooks. No keys or secrets stored here.
 
 **Now vs Future**
 - Now: wallet, dev console, programs, services (API/indexer/timekeeper), SDK/CLI, first bot.

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ This is the **front door** to the Goblin ecosystem: a minimal map of what Goblin
 
 - Vision & layers: see **ARCHITECTURE.md**
 - Repos & links: see **REPO-MAP.md**
+- Bucket 4 (Governance & Economics): **goblin-treasury** *(private)* — treasury ops runbooks
 
 We keep Goblin modular and open. Critical ops remain private.

--- a/REPO-MAP.md
+++ b/REPO-MAP.md
@@ -18,5 +18,6 @@ Buckets are conceptual; repos are the unit of analysis. Links are added as repos
 - goblin-infra — *(private)* IaC, pipelines, secrets
 
 ## 4) Governance & Economics
+- goblin-treasury — *(private)* treasury ops runbooks & docs
 - goblin-dao — *(public scaffold)* future DAO/contracts/UI
 - goblin-governance-private — *(private)* treasury policy, tokenomics, governance docs


### PR DESCRIPTION
- Added `goblin-treasury` repo to Bucket 4
- Updated README.md, REPO-MAP.md, ARCHITECTURE.md
- Clarified role: private repo for treasury operations (runbooks, wallet lists, fee flows, signer roles)
- Reinforced rule: no keys/secrets in Git

------
https://chatgpt.com/codex/tasks/task_e_68b452ccebc88322b56d5a1668550d27