### PR TITLE
docs: add frameworks and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# Goblin — Solana Agent Wallet
-Not an app, a money creature.
+# 🧙 Goblin
 
-This is the **front door** to the Goblin ecosystem: a minimal map of what Goblin is, how it’s structured, and where to find the code.
+Goblin is an autonomous platform that combines **blockchain smart contracts, bots, and developer tooling** with a robust **CI/CD + DevSecOps pipeline**.  
+It is designed to move from **idea → production** quickly and safely, with minimal human oversight.
 
-- Vision & layers: see **ARCHITECTURE.md**
-- Repos & links: see **REPO-MAP.md**
-- Bucket 4 (Governance & Economics): **goblin-treasury** *(private)* — treasury ops runbooks
+---
 
-We keep Goblin modular and open. Critical ops remain private.
+## 📚 Documentation
+
+Core frameworks are stored in the [`/docs`](./docs) folder:
+
+1. **[Test Strategy](./docs/01-test-strategy.md)** – world-class testing framework.  
+2. **[Environment Strategy](./docs/02-environment-strategy.md)** – six environments from Sandbox → Production.  
+3. **[Test + Environment Combined](./docs/03-test-env-combined.md)** – mapping of tests to environments.  
+4. **[CI/CD + DevSecOps + Cloud](./docs/04-cicd-devsecops-cloud.md)** – full automation, GitHub Actions + Google Cloud hosting.
+
+---
+
+## 🚀 At a Glance
+
+- **Code** → lives in this repo (contracts, apps, infra).  
+- **Automation** → GitHub Actions workflows in `.github/workflows/`.  
+- **Hosting** → Google Cloud Run, Cloud SQL/Firestore, Solana Devnet/Testnet/Mainnet.  
+- **Security** → built-in scans, approvals, monitoring, and disaster recovery.  
+
+---
+
+📌 *For details, start in the [`/docs`](./docs) folder.*

--- a/docs/01-test-strategy.md
+++ b/docs/01-test-strategy.md
@@ -1,0 +1,72 @@
+# 🌍 World-Class Best Practice Test Framework (Goblin)
+
+This framework shows **when** each test happens, **what** it checks, and how it relates to release readiness gates.
+
+---
+
+## Phase 1 – Development
+- Static Code Analysis (SAST)
+- Unit Testing
+- Component Testing
+- Code Reviews / Pair Programming
+
+---
+
+## Phase 2 – Build Verification
+- Smoke Testing
+- Sanity Testing (optional)
+
+---
+
+## Phase 3 – QA / Functional Validation
+- Regression Testing
+- Integration Testing
+- System / End-to-End Testing
+- Exploratory Testing
+
+---
+
+## Phase 4 – Non-Functional Testing
+- Performance (load, stress, soak, scalability)
+- Compatibility / Cross-Browser / Cross-Device
+- Accessibility (WCAG/ADA)
+- Chaos / Resilience
+- Data Migration (if relevant)
+
+---
+
+## Phase 5 – Security & Compliance
+- Dynamic App Security Testing (DAST)
+- Penetration Testing
+- Vulnerability Scanning
+- Compliance Testing (PCI, GDPR, HIPAA, etc.)
+
+---
+
+## Phase 6 – Business Validation
+- User Acceptance Testing (UAT)
+- Alpha/Beta Testing
+
+---
+
+## Phase 7 – Operational Readiness
+- Operational Acceptance Testing (OAT)
+- Failover / Disaster Recovery Testing
+- Deployment Testing (Blue-Green, Canary)
+
+---
+
+## Phase 8 – Production / Post-Release
+- Monitoring & Observability
+- Continuous Pen Testing / Red Teaming
+- User Feedback & Telemetry
+- Periodic Regression / Compliance Audits
+
+---
+
+## 📌 Summary
+- Functional: Unit, Integration, System, Regression, UAT
+- Non-Functional: Performance, Compatibility, Accessibility, Chaos, Migration
+- Security: SAST, DAST, Pen Testing, Vulnerability Scans
+- Operational: OAT, DR, Monitoring
+- Release: Alpha, Beta, Canary

--- a/docs/02-environment-strategy.md
+++ b/docs/02-environment-strategy.md
@@ -1,0 +1,54 @@
+# 🏗️ Environment Strategy (Goblin)
+
+A structured environment strategy ensures smooth promotion of code and controlled risk.
+
+---
+
+## 🌱 1. Sandbox
+- Purpose: Experiments & pilots (not on main branch)
+- Tests: Ad-hoc, prototypes
+- Users: Developers
+- Risks: Unstable, insecure
+
+---
+
+## 💻 2. Development
+- Purpose: Active development on `main`
+- Tests: Unit, component, smoke
+- Users: Engineering team
+- Risks: Can break often, optimized for speed
+
+---
+
+## 🔍 3. Test
+- Purpose: QA validation
+- Tests: Regression, integration, end-to-end, exploratory
+- Users: QA & automation
+- Risks: Should mirror production for meaningful results
+
+---
+
+## 🔗 4. Devnet (Solana)
+- Purpose: Blockchain-linked testing on Solana Devnet
+- Tests: Contract deployment, wallet flows, Solana APIs
+- Notes: Safe, resettable
+
+---
+
+## 🌐 5. Testnet (Solana)
+- Purpose: High-fidelity rehearsal
+- Tests: Performance, chaos, compatibility, security
+- Notes: Closer to mainnet conditions
+
+---
+
+## 🚀 6. Production
+- Purpose: Live system
+- Tests: UAT, OAT, DR, canary, monitoring
+- Users: Real users
+- Notes: Strict controls + rollback
+
+---
+
+## 📌 Promotion Flow
+`Sandbox → Development → Test → (Devnet/Testnet as required) → Production`

--- a/docs/03-test-env-combined.md
+++ b/docs/03-test-env-combined.md
@@ -1,0 +1,70 @@
+# 🔗 Combined Test & Environment Framework (Goblin)
+
+This shows which **tests** belong in which **environment**, so Goblin moves safely from idea → live.
+
+---
+
+## 🌱 Sandbox
+- SAST
+- Ad-hoc Unit Testing
+- Prototyping  
+✅ Gate: code runs, rough validation
+
+---
+
+## 💻 Development
+- Unit Tests
+- Component Tests
+- Code Reviews
+- Smoke Tests  
+✅ Gate: stable enough to move to QA
+
+---
+
+## 🔍 Test
+- Regression Testing
+- Integration Testing
+- End-to-End
+- Exploratory
+- Sanity Checks  
+✅ Gate: workflows validated, ready for blockchain testing
+
+---
+
+## 🔗 Devnet (Solana)
+- Contract deployment
+- Wallet flows
+- Solana API integration
+- Early security scans (DAST)  
+✅ Gate: contracts behave correctly on dev cluster
+
+---
+
+## 🌐 Testnet (Solana)
+- Performance & load
+- Chaos & resilience
+- Compatibility
+- Accessibility
+- Security scanning & pen testing
+- Data migration (if relevant)  
+✅ Gate: production-like rehearsal passed
+
+---
+
+## 🚀 Production
+- UAT
+- Alpha/Beta
+- OAT
+- DR drills
+- Canary release
+- Monitoring & observability
+- Continuous pen testing
+- Periodic audits  
+✅ Gate: stable, secure, monitored production
+
+---
+
+## 🗺️ Visual Flow
+
+Sandbox → Development → Test → Devnet → Testnet → Production
+

--- a/docs/04-cicd-devsecops-cloud.md
+++ b/docs/04-cicd-devsecops-cloud.md
@@ -1,0 +1,78 @@
+# 🤖 Goblin CI/CD + DevSecOps + Cloud Hosting Framework
+
+This framework explains how Goblin’s tests, environments, and cloud hosting all connect into one automated lifecycle.  
+The goal is **speed + safety**: changes move from idea → production with minimal human effort, but with strong gates, monitoring, and security.
+
+---
+
+## 🔄 Lifecycle Loop (always repeating)
+
+**Plan → Analyse → Design → Build → Integrate → Test → Deploy → Monitor → Manage → Learn → Adapt**
+
+- **Plan/Analyse/Design:** Ideas and requirements are logged in GitHub (issues/PRs).  
+- **Build/Integrate:** Developers push code → GitHub Actions builds and integrates automatically.  
+- **Test:** Tests run in sequence, mapped to environments.  
+- **Deploy:** Code is promoted into Google Cloud environments with approvals at critical gates.  
+- **Monitor/Manage:** Cloud + GitHub tools watch performance, errors, costs, security.  
+- **Learn/Adapt:** Incidents feed back into improved tests and playbooks.  
+
+---
+
+## 🏗️ Environments + Cloud Hosting
+
+Each Goblin environment has a matching **GCP project**:
+
+- **Sandbox** → quick experiments (no cloud hosting guarantees).  
+- **Development** → deployed to **Cloud Run (Dev)** for rapid smoke + unit tests.  
+- **Test** → full QA on **Cloud Run (Test)** + Cloud SQL/Firestore.  
+- **Devnet (Solana)** → contracts tested against Solana Devnet, API backend in **Cloud Run (Devnet)**.  
+- **Testnet (Solana)** → blockchain rehearsals, load & chaos tests on **Cloud Run (Testnet)**.  
+- **Production** → live services on **Cloud Run (Prod)**, behind a global load balancer with monitoring, backups, and disaster recovery.  
+
+---
+
+## 🚛 CI/CD Assembly Line (GitHub Actions)
+
+Every code change runs through **automated workflows**:
+
+1. **Pull Request → CI**  
+   - Static scans, unit tests, build check.  
+   - Optional preview environment (temporary Cloud Run service).  
+
+2. **Push to `main` → Development**  
+   - Auto-deploy to GCP Dev environment.  
+   - Run smoke tests.  
+
+3. **Promotion → Test**  
+   - Full regression, integration, end-to-end, exploratory.  
+   - Must pass before moving to blockchain-linked tests.  
+
+4. **Release Branch → Devnet → Testnet**  
+   - Solana program deploys + API deploys.  
+   - Performance, chaos, security rehearsals.  
+
+5. **Tag Release → Production**  
+   - Canary (small % traffic).  
+   - Monitoring → rollback if unhealthy.  
+   - Full rollout once stable.  
+
+---
+
+## 🛡️ DevSecOps Safety Nets
+
+Automation adds **security + reliability** everywhere:
+
+- **Before deploy:**  
+  - Code scanning (SAST).  
+  - Dependency checks.  
+  - Vulnerability scans.  
+
+- **During deploy:**  
+  - Canary rollout + auto-rollback.  
+  - Environment gates (approvals for Testnet/Production).  
+  - All secrets pulled from **GCP Secret Manager** (no passwords in code).  
+
+- **After deploy:**  
+  - Monitoring dashboards for uptime, latency, cost.  
+  - Alerts to Slack/Email if error budgets or costs spike.  
+  - Continuous penetration testing & compliance audits.  

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# 📚 Goblin Documentation Index
+
+This folder contains Goblin’s core frameworks for testing, environments, automation, and operations.  
+Together, these four documents explain **how Goblin is built, tested, deployed, and secured**.
+
+---
+
+## 📂 Framework Documents
+
+1. **[01-test-strategy.md](01-test-strategy.md)**  
+   Defines Goblin’s **world-class testing framework**, covering all phases: development, QA, non-functional, security, operational, and production/post-release.
+
+2. **[02-environment-strategy.md](02-environment-strategy.md)**  
+   Outlines the **six environments** Goblin uses (Sandbox, Development, Test, Devnet, Testnet, Production) and their purposes, risks, and promotion flow.
+
+3. **[03-test-env-combined.md](03-test-env-combined.md)**  
+   Maps **which tests run in which environment**, showing how Goblin moves safely from idea to live production.
+
+4. **[04-cicd-devsecops-cloud.md](04-cicd-devsecops-cloud.md)**  
+   Describes Goblin’s **overall CI/CD and DevSecOps automation**, integrating GitHub Actions and Google Cloud hosting to run Goblin with minimal human oversight.
+
+---
+
+## 🧭 How to Use These Docs
+
+- **Developers** → Follow the frameworks to understand where and how tests are run.  
+- **Reviewers** → Use the environment strategy and combined mapping to check readiness gates.  
+- **Operators** → Rely on the CI/CD + DevSecOps framework to manage deployments, monitoring, and security.  
+- **Leaders/Stakeholders** → Use these docs as a clear overview of how Goblin achieves speed, safety, and reliability.
+
+---
+
+📌 *These frameworks evolve with Goblin. Keep them updated whenever new tools, environments, or practices are introduced.*


### PR DESCRIPTION
## Summary
- document world-class testing phases and environment strategy
- map tests to environments and detail CI/CD + DevSecOps cloud workflow
- add docs index and update root README to link framework docs

## Testing
- `npm test` (fails: could not read package.json)
- `cargo test` (fails: could not find `Cargo.toml`)


------
https://chatgpt.com/codex/tasks/task_e_68b501006e808322974ed1f063d71c0d